### PR TITLE
Fix: Prevent duplicate output in markdown2rich

### DIFF
--- a/markdown2rich/cli.py
+++ b/markdown2rich/cli.py
@@ -4,16 +4,18 @@
 import sys
 import argparse
 from pathlib import Path
+import io
 from rich.console import Console
 from rich.markdown import Markdown
 
 
 def render_markdown(content: str, force_terminal: bool = True) -> str:
     """Render markdown content using rich and return as text."""
-    console = Console(record=True, force_terminal=force_terminal)
+    f = io.StringIO()
+    console = Console(file=f, force_terminal=force_terminal)
     md = Markdown(content)
     console.print(md)
-    return console.export_text()
+    return f.getvalue()
 
 
 def main():


### PR DESCRIPTION
The `render_markdown` function was causing duplicate output because the `rich` console was printing to stdout, and the main function was also printing the returned string.

This commit fixes the issue by redirecting the `Console` output to an in-memory `io.StringIO` object. This prevents `rich` from printing directly to standard output. The function then returns the content of the `StringIO` buffer, which is then printed once by the `main` function.

## Summary by Sourcery

Bug Fixes:
- Redirect the rich Console output to an io.StringIO buffer in render_markdown to avoid double-printing the rendered content